### PR TITLE
Only show new game button if game is resolved

### DIFF
--- a/src/app/room/components/room.component.html
+++ b/src/app/room/components/room.component.html
@@ -9,9 +9,9 @@
 <spinner [loadingStatus]="loadingStatus">
   <choice></choice>
   <div class="top-spacer room-button-container">
-    <button mat-raised-button (click)="startOver()">Restart the Game</button>
     <copy-link></copy-link>
     <button mat-raised-button color="accent" (click)="leaveRoom()">Leave the room</button>
+    <button [class.invisible]="!(room$ | async)?.lastOneActive" mat-raised-button color="accent" (click)="startOver()">Another Game</button>
   </div>
 </spinner>
 

--- a/src/app/room/components/room.component.scss
+++ b/src/app/room/components/room.component.scss
@@ -24,3 +24,8 @@
 button {
   margin: 0.2rem;
 }
+
+.invisible {
+  opacity: 0;
+  pointer-events: none;
+}


### PR DESCRIPTION
Used `invisible` class instead of `*ngIf` so the buttons don't jump around. The space for the new game button will be reserved :)

![image](https://user-images.githubusercontent.com/17160319/213148322-91be2d5c-8f91-4434-b631-57531feb8dcd.png)
![image](https://user-images.githubusercontent.com/17160319/213148349-324aa918-285a-421b-bce1-2e8e7f0cec17.png)
