### PR TITLE
create a round only where there are two active players

### DIFF
--- a/firebase-functions/functions/src/constants/keys.ts
+++ b/firebase-functions/functions/src/constants/keys.ts
@@ -1,0 +1,3 @@
+export const keys = {
+  room: 'room',
+};

--- a/firebase-functions/functions/src/operations/playerOperations.ts
+++ b/firebase-functions/functions/src/operations/playerOperations.ts
@@ -19,6 +19,11 @@ export async function resetPlayerChoices(players: QueryDocumentSnapshot<Document
   await updatePlayers(players, { choice: null });
 }
 
+export async function walkoverAPlayer(players: QueryDocumentSnapshot<DocumentData>[], roomId: string): Promise<void> {
+  await updatePlayers(players, { isObserver: true });
+  await admin.firestore().collection(collections.rooms).doc(roomId).update({ lastOneActive: players[0].id });
+}
+
 async function determineLastOneActive(initiallyActivePlayers: QueryDocumentSnapshot<DocumentData>[], playersToDeactivate: QueryDocumentSnapshot<DocumentData>[], roomId: string): Promise<void> {
   const stillActivePlayers = initiallyActivePlayers.filter(player => !playersToDeactivate.includes(player));
   if (stillActivePlayers.length === 1) {


### PR DESCRIPTION
There are two cases where the player can be alone in the room:

1. a player joins the room and no one else joined yet, he can still choose before any other one joins, in that case, his choice should not trigger a round creation.
2. the room has many players, and most of them got eliminated (by winning or losing), there are only two remained players and if one of them decides to leave the room (forfeit) the other players should automatically be the last one active. Now ethically speaking:
---> this could be fair when it is about winning, he/she won every round, and in the last game the opponent drops off, he/she should win this round too.
---> this could be unfair when it is about losing because he/she will be automatically the ultimate loser just because his/her opponent drops off ( I don't know how they handle this in sport honestly)