### PR TITLE
Fix victory count and extend with loser type game

### DIFF
--- a/src/app/firebase/services/firebase-player.service.ts
+++ b/src/app/firebase/services/firebase-player.service.ts
@@ -47,7 +47,7 @@ export class FirebasePlayerService {
     return this.firestore
       .collection<Player>(FirebaseConstants.collections.players, ref => ref
         .where(FirebaseConstants.keys.room, '==', roomId))
-     .get()
+      .get()
       .pipe(
         map(querySnapshot => querySnapshot.forEach(doc => this.updateObservationStatus(doc.id, false))));
   }

--- a/src/app/firebase/services/firebase-room.service.ts
+++ b/src/app/firebase/services/firebase-room.service.ts
@@ -36,9 +36,7 @@ export class FirebaseRoomService {
   }
 
   getNumberOfVictories(roomId: string, playerId?: string): Observable<number> {
-    return this.firestore.collection<Room>(FirebaseConstants.collections.rooms).doc(roomId).get()
-      .pipe(map(room =>
-        room.data()?.games?.filter(game => game.lastOneActive === playerId).length ?? 0
-      ));
+    return this.firestore.collection<Room>(FirebaseConstants.collections.rooms).doc(roomId).valueChanges()
+      .pipe(map(room => room?.games?.filter(game => game.lastOneActive === playerId).length ?? 0));
   }
 }

--- a/src/app/player/components/player.component.html
+++ b/src/app/player/components/player.component.html
@@ -1,11 +1,14 @@
-<div class="player-container" *ngIf="numberOfVictories$ | async as numberOfVictories">
-  <ng-container *ngIf="numberOfVictories">
-    👑<ng-container *ngIf="numberOfVictories > 1">x {{numberOfVictories}}</ng-container>
-  </ng-container>
-</div>
-<div class="player-container" *ngIf="room$ | async as room">
-  <div *ngIf="player?.avatar" SafeInnerHtml [innerHtml]="player?.avatar" class="svg"
-       [class]="{ player: true, observer: player?.isObserver, lastOneActive: isLastOneActive(room.games?.slice(-1)?.[0]?.lastOneActive), loser: room.typeOfGame === gameType.Loser }">
+<ng-container *ngIf="room$ | async as room">
+  <div class="player-container" *ngIf="numberOfVictories$ | async as numberOfVictories">
+    <ng-container *ngIf="numberOfVictories">
+      {{gameType.Winner ? '👑' : '❌'}}
+      <ng-container *ngIf="numberOfVictories > 1">x {{numberOfVictories}}</ng-container>
+    </ng-container>
   </div>
-</div>
-<div class="player-container">{{player?.name}}</div>
+  <div class="player-container">
+    <div *ngIf="player?.avatar" SafeInnerHtml [innerHtml]="player?.avatar" class="svg"
+         [class]="{ player: true, observer: player?.isObserver, lastOneActive: isLastOneActive(room.games?.slice(-1)?.[0]?.lastOneActive), loser: room.typeOfGame === gameType.Loser }">
+    </div>
+  </div>
+  <div class="player-container">{{player?.name}}</div>
+</ng-container>

--- a/src/app/player/components/player.component.ts
+++ b/src/app/player/components/player.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Player } from 'src/app/firebase/models/player';
 import { Room } from '../../firebase/models/room';
 import { Observable } from 'rxjs';
@@ -12,14 +12,16 @@ import { GameType } from '../../room-creation/models/game-type';
   templateUrl: './player.component.html',
   styleUrls: ['./player.component.scss']
 })
-export class PlayerComponent {
+export class PlayerComponent implements OnInit {
   @Input()
   player: Player | undefined;
-  room$: Observable<Room | undefined>;
-  numberOfVictories$: Observable<number>;
+  room$: Observable<Room | undefined> | undefined;
+  numberOfVictories$: Observable<number> | undefined;
   gameType = GameType;
 
-  constructor(private firebaseRoomService: FirebaseRoomService, private route: ActivatedRoute) {
+  constructor(private firebaseRoomService: FirebaseRoomService, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
     const roomId = this.route.snapshot.params[constants.routeParams.id];
     this.room$ = this.firebaseRoomService.roomValueChanges(roomId);
     this.numberOfVictories$ = this.firebaseRoomService.getNumberOfVictories(roomId, this.player?.id);

--- a/src/app/room/components/room.component.ts
+++ b/src/app/room/components/room.component.ts
@@ -107,7 +107,8 @@ export class RoomComponent implements OnInit {
     const action = 'Dismiss';
     this.snackBar.open(message, action, {
       horizontalPosition: 'center',
-      verticalPosition: 'top'
+      verticalPosition: 'top',
+      duration: 3000
     });
   }
 


### PR DESCRIPTION
- Victory count was not updated correctly since `get` was used instead of `valueChanges` (was a real bitch to debug!)
- ❌ is now used to indicate number of loses on `gameType.Loser` 
- constructor stuff was moved to ngOnOnit because `player` input property was not correctly initialized and arrived as `undefined`

![image](https://user-images.githubusercontent.com/17160319/220753148-f88e5bb9-07b2-4fc4-8632-63f8c7d6ae8d.png)

