### PR TITLE
Allow manual run of workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: RPS CD
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Adding this trigger will allow us to run the cd from the browser or CLI. It needs to be on main to be enabled.
This way, we can test changes to the pipeline under real conditions and solve this issue once and for all (hopefully).