### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: DamianReeves/write-file-action@master
         with:
-          path: ./src/environments/environment.ts
+          path: ./src/environments/environment.prod.ts
           contents: |
             ${{ secrets.FIREBASE_CONFIG }}
           write-mode: overwrite
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run build
+      - run: npm run build-prod
       - uses: w9jds/firebase-action@master
         with:
           args: deploy --only hosting

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build-prod": "ng build --configuration=production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "eslint src/**/*"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -49,7 +49,7 @@ import { MatButtonModule } from '@angular/material/button';
       provide: USE_FUNCTIONS_EMULATOR,
       useValue: environment.production ? undefined : ['localhost', 5001],
     },
-    ],
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {


### PR DESCRIPTION
Problem:
- The firebase config stored as secret in our github actions was set to be in development mode
- this led to firebase trying to use the local emulators as defined in `app.module.ts`
Solution:
- change cd pipeline to build in production mode
- as defined in ´angular.json` (and as is [normal for angular apps](https://angular.io/guide/build)), this will make the app use `environment.prod.json` instead of `environment.json`
- now our app runs in production mode when deployed, as it should have anyway :) 

[test here](https://rockpaperscissors-de233.web.app/room/xZYL0RqYIC418vTCUjgJ)